### PR TITLE
Workaround for missing alpaka defines on nvcc.

### DIFF
--- a/nbody/CMakeLists.txt
+++ b/nbody/CMakeLists.txt
@@ -1,17 +1,21 @@
 cmake_minimum_required (VERSION 3.7)
 
-SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+# TODO: use modern cmake?
+
+# Enable it when you need folder organization for your targets,
+# see: https://cliutils.gitlab.io/modern-cmake/chapters/features/ides.html
+# set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 project (mephisto-nbody)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 14)
 
-FIND_PACKAGE(dash-mpi REQUIRED)
+find_package(dash-mpi REQUIRED)
 set(LIBRARIES ${LIBRARIES} ${DASH_LIBRARIES})
 
-SET(LLAMA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../llama/" CACHE STRING "The location of the llama library")
-LIST(APPEND CMAKE_PREFIX_PATH "${LLAMA_ROOT}")
+set(LLAMA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../llama/" CACHE STRING "The location of the llama library")
+list(APPEND CMAKE_PREFIX_PATH "${LLAMA_ROOT}")
 
 find_package(llama 0.1.0 REQUIRED)
 set(INCLUDE_DIRS ${INCLUDE_DIRS} ${llama_INCLUDE_DIR})
@@ -19,7 +23,7 @@ set(INCLUDE_DIRS ${INCLUDE_DIRS} ${LLAMA_ROOT}/examples/common)
 add_definitions(${llama_DEFINITIONS})
 
 set(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../alpaka/" CACHE STRING  "The location of the alpaka library")
-LIST(APPEND CMAKE_PREFIX_PATH "${ALPAKA_ROOT}")
+list(APPEND CMAKE_PREFIX_PATH "${ALPAKA_ROOT}")
 find_package(alpaka REQUIRED)
 
 set(LIBRARIES ${LIBRARIES} ${alpaka_LIBRARIES})
@@ -27,7 +31,14 @@ set(INCLUDE_DIRS ${INCLUDE_DIRS} ${alpaka_INCLUDE_DIRS})
 set(DEFINITIONS ${DEFINITIONS} ${alpaka_DEFINITIONS})
 #set(DEFINITIONS ${DEFINITIONS} ${ALPAKA_DEV_COMPILE_OPTIONS})
 
+# workaround for: NVCC does not incorporate the alpaka defines
+if(ALPAKA_ACC_GPU_CUDA_ENABLE OR ALPAKA_ACC_GPU_HIP_ENABLE)
+    set(_ALPAKA_COMPILE_DEFINITIONS_CUDA ${_ALPAKA_COMPILE_DEFINITIONS_PUBLIC})
+    list_add_prefix("-D" _ALPAKA_COMPILE_DEFINITIONS_CUDA)
+    list(APPEND CUDA_NVCC_FLAGS ${_ALPAKA_COMPILE_DEFINITIONS_CUDA})
+endif()
+
 include_directories(mephisto-nbody ${INCLUDE_DIRS})
-ALPAKA_ADD_EXECUTABLE(mephisto-nbody "nbody.cpp;Dummy.cpp")
+alpaka_add_executable(mephisto-nbody nbody.cpp Dummy.cpp)
 target_compile_options(mephisto-nbody PRIVATE ${DEFINITIONS})
 target_link_libraries(mephisto-nbody PUBLIC ${LIBRARIES})


### PR DESCRIPTION
See diff. Workaround relies on `_ALPAKA_COMPILE_DEFINITIONS_PUBLIC` from alpaka.
Still requires fix on LLAMA to work, see this [PR](https://github.com/ComputationalRadiationPhysics/llama/pull/17).

__At the moment this workaround is only for the nbody example__